### PR TITLE
Fixed #2 - error handling on the database file

### DIFF
--- a/pastebin-mirror/__main__.py
+++ b/pastebin-mirror/__main__.py
@@ -49,7 +49,6 @@ def archive_scrape_pastes(last_archive_time, scraper, storage, rate):
                          if not storage.has_paste_content('paste_content', x['key'])]
         print('[*] Fetching {} new pastes'.format(len(recent_pastes)), file=sys.stderr)
         for paste in recent_pastes:
-            
             key = paste['key']
             storage.save_paste_reference('paste', key, paste['date'], paste['size'],
                                          paste['expire'], paste['title'], paste['syntax'],
@@ -91,7 +90,7 @@ def main():
         storage.initialize_tables(args.trending)
     else:
         storage = FlatFileStorage(location=args.output)
-    
+
     last_scrape = -args.rate
     last_trending = -60 * 60
 

--- a/pastebin-mirror/storage.py
+++ b/pastebin-mirror/storage.py
@@ -55,19 +55,25 @@ class SQLite3Storage:
         self.connection = sqlite3.connect(location)
 
     def initialize_tables(self, trending=False):
-        self.connection.execute(
-            '''
-            CREATE TABLE IF NOT EXISTS paste (
-                paste_key CHAR(8) PRIMARY KEY,
-                timestamp TIMESTAMP,
-                size INT,
-                expires TIMESTAMP,
-                title TEXT,
-                syntax TEXT,
-                user TEXT NULL
-            );
-            '''
-        )
+
+        try:
+          self.connection.execute(
+              '''
+              CREATE TABLE IF NOT EXISTS paste (
+                  paste_key CHAR(8) PRIMARY KEY,
+                  timestamp TIMESTAMP,
+                  size INT,
+                  expires TIMESTAMP,
+                  title TEXT,
+                  syntax TEXT,
+                  user TEXT NULL
+              );
+              '''
+          )
+        except sqlite3.OperationalError as err:
+          print("[!] Error accessing database file: {}".format(err))
+          print("[!] Fatal Error: Exiting...")
+          exit(1)
 
         self.connection.execute(
             '''
@@ -131,7 +137,13 @@ class SQLite3Storage:
             )
         )
 
-        self.connection.commit()
+#        self.connection.commit()
+
+        try:
+          self.connection.commit()
+        except:
+          print("no")
+          raise
 
     def save_paste_content(self, table, key, content):
         self.connection.execute(

--- a/pastebin-mirror/storage.py
+++ b/pastebin-mirror/storage.py
@@ -137,13 +137,7 @@ class SQLite3Storage:
             )
         )
 
-#        self.connection.commit()
-
-        try:
-          self.connection.commit()
-        except:
-          print("no")
-          raise
+        self.connection.commit()
 
     def save_paste_content(self, table, key, content):
         self.connection.execute(


### PR DESCRIPTION
Fixed #2

Added error handling for the initial access of the database. This should catch any access issues, print the error and then exit with a failed return code.

You may want to do more error handling than this in the future, but for now it fixes your issue I think. I'm specifically finding easy bugs to squish to contribute to the community.